### PR TITLE
Fill character '\u2588' causes issues in some envs like mingw-w64

### DIFF
--- a/kflash.py
+++ b/kflash.py
@@ -262,7 +262,7 @@ ISP_PROG2 = binascii.unhexlify(ISP_PROG2)
 ISP_PROG2 = zlib.decompress(ISP_PROG2)
 #print('ISP_FLASH progam size (decompressed)', len(ISP_PROG))
 
-def printProgressBar (iteration, total, prefix = '', suffix = '', decimals = 1, length = 100, fill = '█'):
+def printProgressBar (iteration, total, prefix = '', suffix = '', decimals = 1, length = 100, fill = '='):
     """
     Call in a loop to create terminal progress bar
     @params:


### PR DESCRIPTION
Perhaps we can use something less exotic like equals ('=') instead? 

Exact error message was: UnicodeEncodeError: 'charmap' codec can't encode character '\u2588' in position 19: character maps to <undefined>